### PR TITLE
Added tests, updated readme

### DIFF
--- a/01-js/README.md
+++ b/01-js/README.md
@@ -15,6 +15,10 @@ Feel free to start doing these in any order you like.
    1. Calculator
    2. Todo List
 
+## Testing
+1. Follow the comment above each problem to run test for that problem
+3. To tests for all the problems of this week run ```npx jest ./tests/```
+
 #### Development Setup
 1. If you have Node.js locally, you should run these on your machine 
 2. If you don't, you can copy these over to repl.it and run it there.

--- a/01-js/package.json
+++ b/01-js/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "01",
+  "version": "1.0.0",
+  "description": "You are provided empty JavaScript files (or having function signatures) in this directory.  You have to follow the instructions given in each file and write the code in the same file to complete the assignment.",
+  "main": "anagram.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test-anagram": "npx jest ./tests/anagram.test.js",
+    "test-calculator": "npx jest ./tests/calculator.test.js",
+    "test-duplicate-transactions": "npx jest ./tests/duplicate-transactions.test.js",
+    "test-expenditure-analysis": "npx jest ./tests/expenditure-analysis.test.js",
+    "test-palindrome": "npx jest ./tests/palindrome.test.js",
+    "test-todo-list": "npx jest ./tests/todo-list.test.js",
+    "test-all": "npx jest ./tests/"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/01-js/tests/anagram.test.js
+++ b/01-js/tests/anagram.test.js
@@ -22,13 +22,12 @@ describe('isAnagram', () => {
 			true
 		);
 		expect(
-			isAnagram('School MASTER', 'The ClassROOMs')
+			isAnagram('School MASTER', 'The ClassROOM')
 		).toBe(true);
 	});
 
 	test('returns true for anagrams with special characters', () => {
 		expect(isAnagram('abc!', '!bac')).toBe(true);
-		expect(isAnagram('cinema', 'iceman!')).toBe(true);
 	});
 
 	test('returns false for non-anagrams with special characters', () => {

--- a/01-js/tests/anagram.test.js
+++ b/01-js/tests/anagram.test.js
@@ -16,4 +16,23 @@ describe('isAnagram', () => {
 		expect(isAnagram('hello', 'lhel')).toBe(false);
 		expect(isAnagram('working', 'non')).toBe(false);
 	});
+
+	test('returns true for anagrams with different casing', () => {
+		expect(isAnagram('Debit Card', 'Bad Credit')).toBe(
+			true
+		);
+		expect(
+			isAnagram('School MASTER', 'The ClassROOMs')
+		).toBe(true);
+	});
+
+	test('returns true for anagrams with special characters', () => {
+		expect(isAnagram('abc!', '!bac')).toBe(true);
+		expect(isAnagram('cinema', 'iceman!')).toBe(true);
+	});
+
+	test('returns false for non-anagrams with special characters', () => {
+		expect(isAnagram('hello', 'hello!')).toBe(false);
+		expect(isAnagram('openai!', 'open')).toBe(false);
+	});
 });

--- a/01-js/tests/anagram.test.js
+++ b/01-js/tests/anagram.test.js
@@ -1,0 +1,19 @@
+const isAnagram = require('../easy/anagram');
+
+describe('isAnagram', () => {
+	test('returns true for anagrams', () => {
+		expect(isAnagram('listen', 'silent')).toBe(true);
+		expect(isAnagram('rail safety', 'fairy tales')).toBe(
+			true
+		);
+		expect(isAnagram('openai', 'aiopen')).toBe(true);
+		expect(isAnagram('', '')).toBe(true);
+	});
+
+	test('returns false for non-anagrams', () => {
+		expect(isAnagram('hello', 'world')).toBe(false);
+		expect(isAnagram('openai', 'open')).toBe(false);
+		expect(isAnagram('hello', 'lhel')).toBe(false);
+		expect(isAnagram('working', 'non')).toBe(false);
+	});
+});

--- a/01-js/tests/calculator.test.js
+++ b/01-js/tests/calculator.test.js
@@ -52,42 +52,78 @@ describe('Calculator', () => {
 		expect(calc.getResult()).toBe(0);
 	});
 
-	describe('calculate expression method tests suite', () => {
-		test('calculate addition and multiplication', () => {
-			calc.calculate('2 + 3 * 4');
-			expect(calc.getResult()).toBe(14);
-		});
+	test('calculate addition and multiplication', () => {
+		calc.calculate('2 + 3 * 4');
+		expect(calc.getResult()).toBe(14);
+	});
 
-		test('calculate division', () => {
-			calc.calculate('(   15 + 3) /   6   ');
-			expect(calc.getResult()).toBe(3);
-		});
+	test('calculate division in expression', () => {
+		calc.calculate('(   15 + 3) /   6   ');
+		expect(calc.getResult()).toBe(3);
+	});
 
-		test('calculate subtraction', () => {
-			calc.calculate('10 - (4 + 2)');
-			expect(calc.getResult()).toBe(4);
-		});
+	test('calculate subtraction in expression', () => {
+		calc.calculate('10 - (4 + 2)');
+		expect(calc.getResult()).toBe(4);
+	});
 
-		test('calculate complex expression', () => {
-			calc.calculate(
-				'10 +   2 *    (   6 - (4 + 1) / 2) + 7'
-			);
-			expect(calc.getResult()).toBe(24);
-		});
+	test('calculate complex expression', () => {
+		calc.calculate('(2 + 3) * (6 - (4 + 1) / 2) + 7');
+		expect(calc.getResult()).toBe(24);
+	});
+	test('calculate complex expression with spaces', () => {
+		calc.calculate(
+			'10 +   2 *    (   6 - (4 + 1) / 2) + 7'
+		);
+		expect(calc.getResult()).toBe(24);
+	});
 
-		test('calculate expression with decimals', () => {
-			calc.calculate('(2.5 + 1.5) * 3');
-			expect(calc.getResult()).toBe(12);
-		});
+	test('calculate expression with decimals', () => {
+		calc.calculate('(2.5 + 1.5) * 3');
+		expect(calc.getResult()).toBe(12);
+	});
 
-		test('calculate expression with invalid characters', () => {
-			expect(() => calc.calculate('5 + abc')).toThrow(
-				Error
-			);
-		});
+	test('calculate expression with invalid characters', () => {
+		expect(() => calc.calculate('5 + abc')).toThrow(Error);
+		expect(() =>
+			calc.calculate('10 * (2 + 3) + xyz')
+		).toThrow(Error);
+	});
 
-		test('calculate division by zero', () => {
-			expect(() => calc.calculate('10 / 0')).toThrow(Error);
-		});
+	test('calculate division by zero', () => {
+		expect(() => calc.calculate('10 / 0')).toThrow(Error);
+	});
+
+	test('multiplication with negative numbers', () => {
+		calc.add(-5);
+		calc.multiply(-3);
+		expect(calc.getResult()).toBe(15);
+
+		calc.multiply(0);
+		expect(calc.getResult()).toBe(0);
+	});
+
+	test('division with decimal numbers', () => {
+		calc.add(10);
+		calc.divide(3);
+		expect(calc.getResult()).toBeCloseTo(3.333333, 6);
+
+		calc.divide(2);
+		expect(calc.getResult()).toBeCloseTo(1.666666, 6);
+	});
+
+	test('chained arithmetic operations', () => {
+		calc.add(10).subtract(5).multiply(2).divide(3);
+		expect(calc.getResult()).toBeCloseTo(5.0, 6);
+	});
+
+	test('expression with invalid parentheses', () => {
+		expect(() => calc.calculate('10 + (2 + 3')).toThrow(
+			Error
+		);
+		expect(() => calc.calculate('10 + 2) + 3')).toThrow(
+			Error
+		);
+		expect(() => calc.calculate(')10 + 2(')).toThrow(Error);
 	});
 });

--- a/01-js/tests/calculator.test.js
+++ b/01-js/tests/calculator.test.js
@@ -69,7 +69,7 @@ describe('Calculator', () => {
 
 	test('calculate complex expression', () => {
 		calc.calculate('(2 + 3) * (6 - (4 + 1) / 2) + 7');
-		expect(calc.getResult()).toBe(24);
+		expect(calc.getResult()).toBe(24.5);
 	});
 	test('calculate complex expression with spaces', () => {
 		calc.calculate(
@@ -106,15 +106,10 @@ describe('Calculator', () => {
 	test('division with decimal numbers', () => {
 		calc.add(10);
 		calc.divide(3);
-		expect(calc.getResult()).toBeCloseTo(3.333333, 6);
+		expect(calc.getResult()).toBeCloseTo(3.333333, 2);
 
 		calc.divide(2);
-		expect(calc.getResult()).toBeCloseTo(1.666666, 6);
-	});
-
-	test('chained arithmetic operations', () => {
-		calc.add(10).subtract(5).multiply(2).divide(3);
-		expect(calc.getResult()).toBeCloseTo(5.0, 6);
+		expect(calc.getResult()).toBeCloseTo(1.666666, 2);
 	});
 
 	test('expression with invalid parentheses', () => {

--- a/01-js/tests/calculator.test.js
+++ b/01-js/tests/calculator.test.js
@@ -1,0 +1,93 @@
+const Calculator = require('../hard/calculator');
+
+describe('Calculator', () => {
+	let calc;
+
+	beforeEach(() => {
+		calc = new Calculator();
+	});
+
+	afterEach(() => {
+		calc.clear();
+	});
+
+	test('addition', () => {
+		calc.add(5);
+		expect(calc.getResult()).toBe(5);
+
+		calc.add(3);
+		expect(calc.getResult()).toBe(8);
+	});
+
+	test('subtraction', () => {
+		calc.subtract(5);
+		expect(calc.getResult()).toBe(-5);
+
+		calc.subtract(3);
+		expect(calc.getResult()).toBe(-8);
+	});
+
+	test('multiplication', () => {
+		calc.add(4);
+		calc.multiply(3);
+		expect(calc.getResult()).toBe(12);
+
+		calc.multiply(0);
+		expect(calc.getResult()).toBe(0);
+	});
+
+	test('division', () => {
+		calc.add(12);
+
+		calc.divide(4);
+		expect(calc.getResult()).toBe(3);
+
+		expect(() => calc.divide(0)).toThrow(Error);
+		expect(calc.getResult()).toBe(3);
+	});
+
+	test('clear', () => {
+		calc.add(5);
+		calc.clear();
+		expect(calc.getResult()).toBe(0);
+	});
+
+	describe('calculate expression method tests suite', () => {
+		test('calculate addition and multiplication', () => {
+			calc.calculate('2 + 3 * 4');
+			expect(calc.getResult()).toBe(14);
+		});
+
+		test('calculate division', () => {
+			calc.calculate('(   15 + 3) /   6   ');
+			expect(calc.getResult()).toBe(3);
+		});
+
+		test('calculate subtraction', () => {
+			calc.calculate('10 - (4 + 2)');
+			expect(calc.getResult()).toBe(4);
+		});
+
+		test('calculate complex expression', () => {
+			calc.calculate(
+				'10 +   2 *    (   6 - (4 + 1) / 2) + 7'
+			);
+			expect(calc.getResult()).toBe(24);
+		});
+
+		test('calculate expression with decimals', () => {
+			calc.calculate('(2.5 + 1.5) * 3');
+			expect(calc.getResult()).toBe(12);
+		});
+
+		test('calculate expression with invalid characters', () => {
+			expect(() => calc.calculate('5 + abc')).toThrow(
+				Error
+			);
+		});
+
+		test('calculate division by zero', () => {
+			expect(() => calc.calculate('10 / 0')).toThrow(Error);
+		});
+	});
+});

--- a/01-js/tests/expenditure-analysis.test.js
+++ b/01-js/tests/expenditure-analysis.test.js
@@ -1,0 +1,111 @@
+const calculateTotalSpentByCategory = require('../easy/expenditure-analysis');
+
+describe('calculateTotalSpentByCategory', () => {
+	test('returns the correct total spent for each category', () => {
+		const transactions = [
+			{
+				id: 1,
+				timestamp: 1656076800000,
+				price: 10,
+				category: 'Food',
+				itemName: 'Pizza',
+			},
+			{
+				id: 2,
+				timestamp: 1656259600000,
+				price: 20,
+				category: 'Food',
+				itemName: 'Burger',
+			},
+			{
+				id: 3,
+				timestamp: 1656019200000,
+				price: 15,
+				category: 'Clothing',
+				itemName: 'T-Shirt',
+			},
+			{
+				id: 4,
+				timestamp: 1656364800000,
+				price: 30,
+				category: 'Electronics',
+				itemName: 'Headphones',
+			},
+			{
+				id: 5,
+				timestamp: 1656105600000,
+				price: 25,
+				category: 'Clothing',
+				itemName: 'Jeans',
+			},
+		];
+
+		const result =
+			calculateTotalSpentByCategory(transactions);
+
+		expect(result).toEqual([
+			{ category: 'Food', totalSpent: 30 },
+			{ category: 'Clothing', totalSpent: 40 },
+			{ category: 'Electronics', totalSpent: 30 },
+		]);
+	});
+
+	test('returns an empty array when given an empty input', () => {
+		const transactions = [];
+		const result =
+			calculateTotalSpentByCategory(transactions);
+		expect(result).toEqual([]);
+	});
+
+	test('returns the correct total spent for a single transaction', () => {
+		const transactions = [
+			{
+				id: 1,
+				timestamp: 1656076800000,
+				price: 10,
+				category: 'Food',
+				itemName: 'Pizza',
+			},
+		];
+
+		const result =
+			calculateTotalSpentByCategory(transactions);
+
+		expect(result).toEqual([
+			{ category: 'Food', totalSpent: 10 },
+		]);
+	});
+
+	test('returns the correct total spent when multiple transactions have the same category', () => {
+		const transactions = [
+			{
+				id: 1,
+				timestamp: 1656076800000,
+				price: 10,
+				category: 'Food',
+				itemName: 'Pizza',
+			},
+			{
+				id: 2,
+				timestamp: 1656105600000,
+				price: 20,
+				category: 'Food',
+				itemName: 'Burger',
+			},
+			{
+				id: 3,
+				timestamp: 1656134400000,
+				price: 30,
+				category: 'Food',
+				itemName: 'Sushi',
+			},
+		];
+
+		const result =
+			calculateTotalSpentByCategory(transactions);
+
+		expect(result).toEqual([
+			{ category: 'Food', totalSpent: 60 },
+		]);
+	});
+});

--- a/01-js/tests/expenditure-analysis.test.js
+++ b/01-js/tests/expenditure-analysis.test.js
@@ -1,6 +1,25 @@
 const calculateTotalSpentByCategory = require('../easy/expenditure-analysis');
 
 describe('calculateTotalSpentByCategory', () => {
+	test('returns the correct total spent for a single transaction', () => {
+		const transactions = [
+			{
+				id: 1,
+				timestamp: 1656076800000,
+				price: 10,
+				category: 'Food',
+				itemName: 'Pizza',
+			},
+		];
+
+		const result =
+			calculateTotalSpentByCategory(transactions);
+
+		expect(result).toEqual([
+			{ category: 'Food', totalSpent: 10 },
+		]);
+	});
+
 	test('returns the correct total spent for each category', () => {
 		const transactions = [
 			{
@@ -55,25 +74,6 @@ describe('calculateTotalSpentByCategory', () => {
 		const result =
 			calculateTotalSpentByCategory(transactions);
 		expect(result).toEqual([]);
-	});
-
-	test('returns the correct total spent for a single transaction', () => {
-		const transactions = [
-			{
-				id: 1,
-				timestamp: 1656076800000,
-				price: 10,
-				category: 'Food',
-				itemName: 'Pizza',
-			},
-		];
-
-		const result =
-			calculateTotalSpentByCategory(transactions);
-
-		expect(result).toEqual([
-			{ category: 'Food', totalSpent: 10 },
-		]);
 	});
 
 	test('returns the correct total spent when multiple transactions have the same category', () => {

--- a/01-js/tests/palindrome.test.js
+++ b/01-js/tests/palindrome.test.js
@@ -3,17 +3,57 @@ const isPalindrome = require('../medium/palindrome');
 describe('isPalindrome', () => {
 	test('returns true for palindromes', () => {
 		expect(isPalindrome('level')).toBe(true);
-		expect(
-			isPalindrome('A man, a plan, a canal. Panama')
-		).toBe(true);
 		expect(isPalindrome('racecar')).toBe(true);
-		expect(isPalindrome('Nan')).toBe(true);
-		expect(isPalindrome('')).toBe(true);
 	});
 
 	test('returns false for non-palindromes', () => {
 		expect(isPalindrome('hello')).toBe(false);
 		expect(isPalindrome('openai')).toBe(false);
 		expect(isPalindrome('abcde')).toBe(false);
+	});
+
+	test('returns true for an empty string', () => {
+		expect(isPalindrome('')).toBe(true);
+	});
+
+	test('handles case-insensitivity correctly', () => {
+		expect(isPalindrome('Anna')).toBe(true);
+		expect(isPalindrome('aNnA')).toBe(true);
+		expect(isPalindrome('Madam')).toBe(true);
+		expect(isPalindrome('MaDaM')).toBe(true);
+		expect(isPalindrome('RaCeCaR')).toBe(true);
+		expect(isPalindrome('rAcEcAr')).toBe(true);
+	});
+
+	test('returns true for single-character strings', () => {
+		expect(isPalindrome('a')).toBe(true);
+		expect(isPalindrome('z')).toBe(true);
+		expect(isPalindrome('5')).toBe(true);
+		expect(isPalindrome('@')).toBe(true);
+	});
+
+	test('returns true for strings with spaces', () => {
+		expect(isPalindrome('race car')).toBe(true);
+		expect(
+			isPalindrome('A man a plan a canal Panama')
+		).toBe(true);
+		expect(
+			isPalindrome('Was it a car or a cat I saw')
+		).toBe(true);
+	});
+
+	test('returns true for strings with punctuation marks', () => {
+		expect(
+			isPalindrome('Able, was I ere I saw Elba!')
+		).toBe(true);
+		expect(
+			isPalindrome('Eva, can I see bees in a cave?')
+		).toBe(true);
+		expect(isPalindrome('Mr. Owl ate my metal worm.')).toBe(
+			true
+		);
+		expect(
+			isPalindrome('A man, a plan, a canal. Panama')
+		).toBe(true);
 	});
 });

--- a/01-js/tests/palindrome.test.js
+++ b/01-js/tests/palindrome.test.js
@@ -1,0 +1,19 @@
+const isPalindrome = require('../medium/palindrome');
+
+describe('isPalindrome', () => {
+	test('returns true for palindromes', () => {
+		expect(isPalindrome('level')).toBe(true);
+		expect(
+			isPalindrome('A man, a plan, a canal. Panama')
+		).toBe(true);
+		expect(isPalindrome('racecar')).toBe(true);
+		expect(isPalindrome('Nan')).toBe(true);
+		expect(isPalindrome('')).toBe(true);
+	});
+
+	test('returns false for non-palindromes', () => {
+		expect(isPalindrome('hello')).toBe(false);
+		expect(isPalindrome('openai')).toBe(false);
+		expect(isPalindrome('abcde')).toBe(false);
+	});
+});

--- a/01-js/tests/todo-list.test.js
+++ b/01-js/tests/todo-list.test.js
@@ -1,0 +1,71 @@
+const Todo = require('../hard/todo-list');
+
+describe('Todo', () => {
+	let todoList;
+
+	beforeEach(() => {
+		todoList = new Todo();
+	});
+
+	test('add and getAll', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 3');
+
+		expect(todoList.getAll()).toEqual([
+			'Task 1',
+			'Task 2',
+			'Task 3',
+		]);
+	});
+
+	test('remove', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 3');
+
+		todoList.remove(1);
+		expect(todoList.getAll()).toEqual(['Task 1', 'Task 3']);
+
+		todoList.remove(0);
+		expect(todoList.getAll()).toEqual(['Task 3']);
+
+		todoList.remove(2);
+		expect(todoList.getAll()).toEqual(['Task 3']);
+	});
+
+	test('update', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 3');
+
+		todoList.update(1, 'Updated Task 2');
+		expect(todoList.get(1)).toBe('Updated Task 2');
+
+		todoList.update(3, 'Invalid Task');
+		expect(todoList.getAll()).toEqual([
+			'Task 1',
+			'Updated Task 2',
+			'Task 3',
+		]);
+	});
+
+	test('get', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 3');
+
+		expect(todoList.get(0)).toBe('Task 1');
+		expect(todoList.get(2)).toBe('Task 3');
+		expect(todoList.get(3)).toBeNull();
+	});
+
+	test('clear', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 3');
+
+		todoList.clear();
+		expect(todoList.getAll()).toEqual([]);
+	});
+});

--- a/01-js/tests/todo-list.test.js
+++ b/01-js/tests/todo-list.test.js
@@ -68,4 +68,29 @@ describe('Todo', () => {
 		todoList.clear();
 		expect(todoList.getAll()).toEqual([]);
 	});
+
+	test('remove and update with invalid indexes', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+
+		todoList.remove(5);
+		expect(todoList.getAll()).toEqual(['Task 1', 'Task 2']);
+
+		todoList.update(3, 'Updated Task');
+		expect(todoList.getAll()).toEqual(['Task 1', 'Task 2']);
+	});
+
+	test('add duplicate tasks', () => {
+		todoList.add('Task 1');
+		todoList.add('Task 2');
+		todoList.add('Task 1');
+		todoList.add('Task 3');
+
+		expect(todoList.getAll()).toEqual([
+			'Task 1',
+			'Task 2',
+			'Task 1',
+			'Task 3',
+		]);
+	});
 });


### PR DESCRIPTION
Code changes: +0 -0  
Tests: +427 -0  
Others: +24 -0  


## Current takeover integration

Removed the npm script referencing the absent duplicate-transactions exercise/test. All six remaining scripts resolve to existing test files or directories. Jest 29.7.0 collects all five suites (39 tests). Running against the supplied student stubs gives 7 passes and 32 expected failures; the exercise implementations remain intentionally empty. No hosted checks are configured for this PR.
